### PR TITLE
explicitly use string in shutdown timeout & bump checkout to `v4`

### DIFF
--- a/.github/workflows/create-vm.yml
+++ b/.github/workflows/create-vm.yml
@@ -27,7 +27,7 @@ jobs:
       machine-zone: ${{ steps.create-runner.outputs.machine-zone }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Authenticate to Google Cloud
         id: auth
         if: github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name      

--- a/action.yml
+++ b/action.yml
@@ -45,7 +45,7 @@ inputs:
     required: true
   shutdown_timeout:
     description: "Shutdown grace period (in seconds)."
-    default: 30
+    default: 30s
     required: true
   task:
     description: Additional context about the workflow
@@ -76,7 +76,7 @@ runs:
         echo "❌ Job actions are not allowed to run in forks" >> $GITHUB_STEP_SUMMARY
         exit 1
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Authenticate to Google Cloud
       id: auth
       if: github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

This PR does the following: 
- Bumps checkout actions to `v4` (LTS)
- Fixes out the action.yml error to require for string and not an integer as shutdown timeout:
    
    <img width="894" alt="image" src="https://github.com/gitpod-io/gce-github-runner/assets/55068936/2e0c812b-a583-4560-8dcb-cdf0d93c8706">


## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

/hold
