### PR TITLE
Add label input to allow recreating the VM

### DIFF
--- a/.github/workflows/create-vm.yml
+++ b/.github/workflows/create-vm.yml
@@ -47,7 +47,7 @@ jobs:
         run: |
           gcloud auth activate-service-account --key-file ${{ steps.auth.outputs.credentials_file_path }}
       - id: create-runner
-        uses: gitpod-io/gce-github-runner@${{ github.sha }}
+        uses: gitpod-io/gce-github-runner@wv/add-label-input
         with:
           runner_token: ${{ secrets.runner_token }}
           task: ${{ inputs.task }}

--- a/.github/workflows/create-vm.yml
+++ b/.github/workflows/create-vm.yml
@@ -47,8 +47,9 @@ jobs:
         run: |
           gcloud auth activate-service-account --key-file ${{ steps.auth.outputs.credentials_file_path }}
       - id: create-runner
-        uses: gitpod-io/gce-github-runner@main
+        uses: gitpod-io/gce-github-runner@${{ github.sha }}
         with:
           runner_token: ${{ secrets.runner_token }}
           task: ${{ inputs.task }}
+          label: ${{ inputs.label }}
           gcp_credentials: ${{ secrets.gcp_credentials }}

--- a/.github/workflows/create-vm.yml
+++ b/.github/workflows/create-vm.yml
@@ -47,7 +47,7 @@ jobs:
         run: |
           gcloud auth activate-service-account --key-file ${{ steps.auth.outputs.credentials_file_path }}
       - id: create-runner
-        uses: gitpod-io/gce-github-runner@wv/add-label-input
+        uses: gitpod-io/gce-github-runner@main
         with:
           runner_token: ${{ secrets.runner_token }}
           task: ${{ inputs.task }}

--- a/.github/workflows/create-vm.yml
+++ b/.github/workflows/create-vm.yml
@@ -7,6 +7,12 @@ on:
         type: string
         required: false
         default: "default"
+      # If set, use this label instead of generating a random one (and 'task' will be ignored).
+      # Useful to recreate a runner VM that got shutdown.
+      label:
+        type: string
+        required: false
+        default: ""
     secrets:
       gcp_credentials:
         required: true
@@ -30,13 +36,13 @@ jobs:
         uses: actions/checkout@v4
       - name: Authenticate to Google Cloud
         id: auth
-        if: github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name      
+        if: github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name
         uses: google-github-actions/auth@v1
         with:
           credentials_json: ${{ secrets.gcp_credentials }}
       - name: Activate GCP service account
         id: gcloud-auth
-        if: github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name      
+        if: github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name
         shell: bash
         run: |
           gcloud auth activate-service-account --key-file ${{ steps.auth.outputs.credentials_file_path }}
@@ -44,5 +50,5 @@ jobs:
         uses: gitpod-io/gce-github-runner@main
         with:
           runner_token: ${{ secrets.runner_token }}
-          task: ${{ inputs.task }}        
+          task: ${{ inputs.task }}
           gcp_credentials: ${{ secrets.gcp_credentials }}

--- a/action.yml
+++ b/action.yml
@@ -39,6 +39,11 @@ inputs:
   image_family:
     description: The image family for the operating system that the boot disk will be initialized with.
     required: false
+  label:
+    description: >-
+      Runner label. Can be set to override the VM name to recreate a runner with a specific label,
+      e.g. to replace a runner that was shutdown. If set, 'task' will be ignored.
+    required: false
   scopes:
     description: Scopes granted to the VM, defaults to full access (cloud-platform).
     default: cloud-platform
@@ -108,5 +113,6 @@ runs:
           --image_project=${{ inputs.image_project }} \
           --image=${{ inputs.image }} \
           --image_family=${{ inputs.image_family }} \
+          --label=${{ inputs.label }} \
           --boot_disk_type=pd-ssd \
           --task=${{ inputs.task }}


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Add `label` input, to create the VM under a specific name, to allow recreating a workflow's VM if it disappeared (timeout, or shutdown in another way)

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

Tested to unblock this workflow for which the VM timed out: https://github.com/gitpod-io/gitpod-dedicated/actions/runs/6717740440/job/18262874377, and worked

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

/hold
