### PR TITLE
Bump go version to 1.23

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -35,7 +35,7 @@ inputs:
   image:
     description: Specifies the name of the image that the disk will be initialized with.
     required: false
-    default: gh-runner-202409170936
+    default: gh-runner-202409261826
   image_family:
     description: The image family for the operating system that the boot disk will be initialized with.
     required: false

--- a/vm/rootfs/setup-runner.sh
+++ b/vm/rootfs/setup-runner.sh
@@ -9,7 +9,7 @@ set -e
 # same Go version during development as we do in CI - which allows us to
 # reuse the leeway cache
 #
-GO_VERSION=1.22.2
+GO_VERSION=1.23.1
 GOPATH=/home/runner/go-packages
 GOROOT=/home/runner/go
 PATH=$GOROOT/bin:$GOPATH/bin:$PATH


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
This is required to bump deps for our autoscaler-expander in Enterprise Now.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Related to ENT-778

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

/hold
