### PR TITLE
Pin VM runner workflows to Ubuntu 22.04

### DIFF
--- a/.github/workflows/create-vm.yml
+++ b/.github/workflows/create-vm.yml
@@ -27,7 +27,7 @@ on:
 jobs:
   run:
     name: Create GCE VM
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     outputs:
       label: ${{ steps.create-runner.outputs.label }}
       machine-zone: ${{ steps.create-runner.outputs.machine-zone }}

--- a/.github/workflows/delete-vm.yml
+++ b/.github/workflows/delete-vm.yml
@@ -16,7 +16,7 @@ on:
 
 jobs:
   run:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     name: Delete ephemeral GCE VM
     steps:
       - id: auth


### PR DESCRIPTION
This pull request pins the runner workflows to use Ubuntu 22.04 instead of the `latest` version. Because, GHA will be using Ubuntu 24 (very soon - Oct 30th 2024) -- https://github.com/actions/runner-images/issues/10636